### PR TITLE
Bump requests to 2.20.1 to address CVE-2018-18074

### DIFF
--- a/services/exercises/requirements.txt
+++ b/services/exercises/requirements.txt
@@ -8,4 +8,4 @@ Flask-SQLAlchemy==2.3.2
 Flask-Testing==0.6.2
 gunicorn==19.8.1
 psycopg2-binary==2.7.5
-requests==2.19.1
+requests==2.20.1


### PR DESCRIPTION
**CVE-2018-18074
Vulnerable versions: <= 2.19.1
Patched version: 2.20.0**

The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.

More info: https://nvd.nist.gov/vuln/detail/CVE-2018-18074